### PR TITLE
fixed namespace string replacements

### DIFF
--- a/bin/scala-bootstrapper
+++ b/bin/scala-bootstrapper
@@ -34,12 +34,12 @@ end
 
 def gsub_birds(haystack, name, namespace)
   haystack.
+    gsub("com.twitter.birdname", "#{namespace}.#{name.downcase}").
+    gsub("com/twitter/birdname", "#{namespace.gsub('.', '/')}/#{name.downcase}").
     gsub("BirdName", name).
     gsub("birdname", name.downcase).
     gsub("bird_name", name.underscore).
-    gsub("birdName", name.camelize).
-    gsub("com.twitter", namespace).
-    gsub("com/twitter", namespace.gsub(".", "/"))
+    gsub("birdName", name.camelize)
 end
 
 require "erb"


### PR DESCRIPTION
Commands with namespaces like this:

scala-bootstrapper -n com.twitter.namespace project
scala-bootstrapper -n foo.namespace project

were generating lines like this, respectively:

import com.twitter.namespace.ostrich.admin._
import foo.namespace.ostrich.admin._
