### PR TITLE
Fix admin port in shutdown tutorial example

### DIFF
--- a/lib/template/TUTORIAL.md
+++ b/lib/template/TUTORIAL.md
@@ -76,7 +76,7 @@ Ostrich also stores historial stats data and can build
 
 You can ask the server to shutdown over the admin port also:
 
-    $ curl localhost:9990/shutdown.txt
+    $ curl localhost:9900/shutdown.txt
     ok
 
 ### View the implementation of get() and put()


### PR DESCRIPTION
The code example in the "Stop the service" section currently lists port 9990 instead of the default admin port 9900. Changed the code example so it's more straightforward for newcomers.
