### PR TITLE
Rm trailing whitespace in template files

### DIFF
--- a/lib/template/config/development.scala.erb
+++ b/lib/template/config/development.scala.erb
@@ -5,9 +5,9 @@ import com.twitter.birdname.config._
 
 // development mode.
 new BirdNameServiceConfig {
-	
+
   // Add your own config here
-  
+
   // Where your service will be exposed.
   thriftPort = 9999
 
@@ -15,9 +15,9 @@ new BirdNameServiceConfig {
   admin.httpPort = 9900
 
   // End user configuration
-  
-  // Expert-only: Ostrich stats and logger configuration.  
-  
+
+  // Expert-only: Ostrich stats and logger configuration.
+
   admin.statsNodes = new StatsConfig {
     reporters = new JsonStatsLoggerConfig {
       loggerName = "stats"

--- a/lib/template/config/production.scala.erb
+++ b/lib/template/config/production.scala.erb
@@ -5,9 +5,9 @@ import com.twitter.birdname.config._
 
 // production mode.
 new BirdNameServiceConfig {
-	
+
   // Add your own config here
-  
+
   // Where your service will be exposed.
   thriftPort = 9999
 
@@ -15,7 +15,7 @@ new BirdNameServiceConfig {
   admin.httpPort = 9900
 
   // End user configuration
-  
+
   // Expert-only: Ostrich stats and logger configuration.
   admin.statsNodes = new StatsConfig {
     reporters = new JsonStatsLoggerConfig {

--- a/lib/template/config/staging.scala.erb
+++ b/lib/template/config/staging.scala.erb
@@ -5,9 +5,9 @@ import com.twitter.birdname.config._
 
 // staging mode.
 new BirdNameServiceConfig {
-	
+
   // Add your own config here
-  
+
   // Where your service will be exposed.
   thriftPort = 9999
 
@@ -15,7 +15,7 @@ new BirdNameServiceConfig {
   admin.httpPort = 9900
 
   // End user configuration
-  
+
   // Expert-only: Ostrich stats and logger configuration.
   admin.statsNodes = new StatsConfig {
     reporters = new JsonStatsLoggerConfig {

--- a/lib/template/config/test.scala.erb
+++ b/lib/template/config/test.scala.erb
@@ -5,9 +5,9 @@ import com.twitter.birdname.config._
 
 // test mode.
 new BirdNameServiceConfig {
-	
+
   // Add your own config here
-  
+
   // Where your service will be exposed.
   thriftPort = 9999
 
@@ -15,7 +15,7 @@ new BirdNameServiceConfig {
   admin.httpPort = 9900
 
   // End user configuration
-  
+
   // Expert-only: Ostrich stats and logger configuration.
   admin.statsNodes = new StatsConfig {
     reporters = new JsonStatsLoggerConfig {

--- a/lib/template/project/build/BirdNameProject.scala.erb
+++ b/lib/template/project/build/BirdNameProject.scala.erb
@@ -9,10 +9,10 @@ import com.twitter.sbt._
  *     val example = "com.example" % "exampleland" % "1.0.3"
  * mean to add a dependency on exampleland version 1.0.3 from provider "com.example".
  */
-class BirdNameProject(info: ProjectInfo) extends StandardServiceProject(info) 
-  with CompileThriftScala 
-  with NoisyDependencies 
-  with DefaultRepos 
+class BirdNameProject(info: ProjectInfo) extends StandardServiceProject(info)
+  with CompileThriftScala
+  with NoisyDependencies
+  with DefaultRepos
   with SubversionPublisher
   with PublishSourcesAndJavadocs
   with PublishSite
@@ -29,7 +29,7 @@ class BirdNameProject(info: ProjectInfo) extends StandardServiceProject(info)
 
   override def originalThriftNamespaces = Map("BirdName" -> "com.twitter.birdname.thrift")
   override val scalaThriftTargetNamespace = "com.twitter.birdname"
-  
+
   val slf4jVersion = "1.5.11"
   val slf4jApi = "org.slf4j" % "slf4j-api" % slf4jVersion withSources() intransitive()
   val slf4jBindings = "org.slf4j" % "slf4j-jdk14" % slf4jVersion withSources() intransitive()

--- a/lib/template/src/main/scala/com/twitter/birdname/BirdNameServiceImpl.scala.erb
+++ b/lib/template/src/main/scala/com/twitter/birdname/BirdNameServiceImpl.scala.erb
@@ -8,23 +8,23 @@ import config._
 class BirdNameServiceImpl(config: BirdNameServiceConfig) extends BirdNameServiceServer {
   val serverName = "BirdName"
   val thriftPort = config.thriftPort
-  
+
   /**
-   * These services are based on finagle, which implements a nonblocking server.  If you 
+   * These services are based on finagle, which implements a nonblocking server.  If you
    * are making blocking rpc calls, it's really important that you run these actions in
    * a thread pool, so that you don't block the main event loop.  This thread pool is only
    * needed for these blocking actions.  The code looks like:
    *
    *     // Depends on com.twitter.util >= 1.6.10
    *     val futurePool = new FuturePool(Executors.newFixedThreadPool(config.threadPoolSize))
-   * 
+   *
    *     def hello() = futurePool {
    *       someService.blockingRpcCall
    *     }
-   * 
-   */   
+   *
+   */
 
-  val database = new mutable.HashMap[String, String]()  
+  val database = new mutable.HashMap[String, String]()
 
   def get(key: String) = {
     database.get(key) match {

--- a/lib/template/src/scripts/startup.sh
+++ b/lib/template/src/scripts/startup.sh
@@ -65,7 +65,7 @@ case "$1" in
       echo "already running."
       exit 0
     fi
-    
+
     ulimit -c unlimited || echo -n " (no coredump)"
     $DAEMON $daemon_args $daemon_start_args -- sh -c "echo "'$$'" > $pidfile; exec ${JAVA_HOME}/bin/java ${JAVA_OPTS} -jar ${APP_HOME}/${JAR_NAME}"
     tries=0
@@ -113,7 +113,7 @@ case "$1" in
     done
     echo "done."
   ;;
-  
+
   status)
     if running; then
       echo "$APP_NAME is running."

--- a/lib/template/src/test/scala/com/twitter/birdname/AbstractSpec.scala.erb
+++ b/lib/template/src/test/scala/com/twitter/birdname/AbstractSpec.scala.erb
@@ -9,7 +9,7 @@ abstract class AbstractSpec extends Specification {
   val env = RuntimeEnvironment(this, Array("-f", "config/test.scala"))
   lazy val birdName = {
     val out = env.loadRuntimeConfig[BirdNameService]
-    
+
     // You don't really want the thrift server active, particularly if you
     // are running repetitively via ~test
     ServiceTracker.shutdown // all services


### PR DESCRIPTION
Numerous generated Scala files contain trailing whitespace. Fixed the relevant templates to prevent this.
