### PR TITLE
Changed require for rdoc/task to work rake 10.3

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -42,7 +42,7 @@ task :test => :check_dependencies
 
 task :default => :test
 
-require 'rake/rdoctask'
+require 'rdoc/task'
 Rake::RDocTask.new do |rdoc|
   version = File.exist?('VERSION') ? File.read('VERSION') : ""
 


### PR DESCRIPTION
rake build is throwing error 

rake aborted!
ERROR: 'rake/rdoctask' is obsolete and no longer supported. Use 'rdoc/task' (available in RDoc 2.4.2+) instead.

Changed require for rdoc/task to work rake 10.3. 
